### PR TITLE
unconditional sp-validation cert creation & timeouts

### DIFF
--- a/charts/linkerd-issuers/templates/certificate.yml
+++ b/charts/linkerd-issuers/templates/certificate.yml
@@ -43,7 +43,6 @@ spec:
   usages:
     - server auth
 
-{{ if (.Values.installLinkerdViz) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -65,7 +64,6 @@ spec:
     algorithm: ECDSA
   usages:
     - server auth
-{{ end }}
 
 {{ if (.Values.installLinkerdViz) }}
 ---

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "helm_release" "issuer" {
   name       = "linkerd-issuer"
   namespace  = "linkerd"
   chart      = "${path.module}/charts/linkerd-issuers"
-
+  timeout    = var.linkerd_helm_install_timeout_secs
   values = [
     yamlencode({
       installLinkerdViz    = contains(var.namespaces, "linkerd-viz") ? true : false

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,10 @@ variable "certificate_webhook_renewbefore" {
   type        = string
   default     = "48h"
 }
+
+
+variable "linkerd_helm_install_timeout_secs" {
+  description = "The number of seconds to wait for the linkerd chart to be deployed. the default is 900 (15 minutes)"
+  type = string
+  default = "900"
+}


### PR DESCRIPTION
2 changes

- Removed conditional creation of sp-validattor cert.  The secret linkerd-sp-validator-k8s-tls from cert linked-sp-validator is required to be installed for linkerd to start.  Previously the creation of the cert was based on whether or not linkerd-viz was being added.  This cert is needed by the base linkerd install.
- Added configurable timeout for linkerd chart to be installed, defaulted to 15 mins.  I've observed that occasionally it can take a long time to download the linkerd images and thus it can take a while before helm reports the pods are installed.

thanks

Mike McAllister