### PR TITLE
Create viz-role-rolebinding.yml

### DIFF
--- a/modules/issuer/chart/templates/viz-role-rolebinding.yml
+++ b/modules/issuer/chart/templates/viz-role-rolebinding.yml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ext-namespace-metadata-linkerd-config
+  namespace: linkerd
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["linkerd-config"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ext-namespace-metadata-linkerd-config
+  namespace: linkerd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ext-namespace-metadata-linkerd-config
+subjects:
+- kind: ServiceAccount
+  name: namespace-metadata
+  namespace: linkerd-viz


### PR DESCRIPTION
**Issue**

- While deploying this helm chart, pods are not coming up in the linkerd-viz namespace, and they are looking for a role, and role binding TFE is failing to deploy this chart

**Resolution**

- I added role and role-binding, which will help the pods to come up clean, and the helm chart.